### PR TITLE
Endre hintIsPublic fra boolsk verdi til enum

### DIFF
--- a/src/Handlevogn.ts
+++ b/src/Handlevogn.ts
@@ -1,7 +1,13 @@
 type Handlevogn = {
     orgNr: string,
     system: string,
-    hintIsPublic: string,
+    accessRights: AccessRights,
     language: string,
     dataDef: string,
+}
+
+enum AccessRights {
+    PUBLIC = 'PUBLIC',
+    RESTRICTED = 'RESTRICTED',
+    NON_PUBLIC = 'NON_PUBLIC',
 }


### PR DESCRIPTION
Jeg synes ikke hintet om datasettet er offentlig burde være en boolsk verdi, da det er vanskelig å utvide dette om vi får behov for det senere. Foreslår derfor at det er et enum, siden det kan utvides uten å innføre en breaking change. Jeg foreslår å bruke [verdiene fra digitaliseringsdirektoratet](https://data.norge.no/specification/dcat-ap-no#Datasett-tilgangsniv%C3%A5), som er `public`, `restricted` og `non-public`.

