### PR TITLE
Legg til applicationProcessEmail i Resolver

### DIFF
--- a/src/Resolver.ts
+++ b/src/Resolver.ts
@@ -1,4 +1,5 @@
 type Resolver = {
     title: string,
     description: string,
+    applicationProcessEmail?: string
 }


### PR DESCRIPTION
Se https://entur.slack.com/archives/C05TE7H2BEG/p1729166591876279 for diskusjon på slack.

Hei! Har dere gjort noen tanker om epostutsendelse og hvordan det skal gjøres? Om ikke foreslår jeg at vi legger til en epostadresse i resolveren og at det altid sendes en generisk epost til denne adressen.

En ulempe med dette kan være at ikke nødvendigvis alle dataeierene ønsker epost. Særlig de med eget behandlingssystem som automatiserer alt bryr seg jo egentlig ikke om dette. En mulig løsning på dette er at applicationProcessEmail er nullable. Om den ikke finnes sendes det ingen epost.

Altså blir resolver responsen seende slik ut:
```
{ 
  "title": string, 
  "description": string, 
  "applicationProcessEmail": string? 
}
```

og dersom applicationProcessEmail ikke er null sendes det ut en epost à la
"Person x med epost y ønsker tilgang til datasett ${resolverResponse.title}" til eposten i resolverResponse.applicationProcessEmail

